### PR TITLE
disable cp parallel

### DIFF
--- a/videosys/core/parallel_mgr.py
+++ b/videosys/core/parallel_mgr.py
@@ -85,7 +85,7 @@ def initialize(
     init_method=None,
     seed: Optional[int] = None,
     sp_size: Optional[int] = None,
-    enable_cp: bool = True,
+    enable_cp: bool = False,
 ):
     if not dist.is_initialized():
         try:
@@ -107,7 +107,8 @@ def initialize(
         dp_size = dist.get_world_size() // sp_size
 
     # update cfg parallel
-    if enable_cp and sp_size % 2 == 0:
+    # NOTE: enable cp parallel will be slower. disable it for now.
+    if False and enable_cp and sp_size % 2 == 0:
         sp_size = sp_size // 2
         cp_size = 2
     else:


### PR DESCRIPTION
As mentioned in issue #189 #191 , the efficiency of context parallel is low. So we turn it off by default now. Will investigate how to make it more efficient in future.

Thanks the contribution of @chen-yy20 and @gttiankai