### PR TITLE
[hotfix] fix CogVideoX parallel bug with 4 gpus

### DIFF
--- a/videosys/models/transformers/cogvideox_transformer_3d.py
+++ b/videosys/models/transformers/cogvideox_transformer_3d.py
@@ -52,9 +52,26 @@ class CogVideoXAttnProcessor2_0:
         for i in range(sp_size):
             new_seq.append(split_seq[i][:, :, text_seq_length:])
         hidden_states = torch.cat(new_seq, dim=2)
+
+        # remove padding added when all2all
+        # if pad is removed earlier than this
+        # the split size will be wrong
+        pad = get_pad("pad")
+        if pad > 0:
+            hidden_states = hidden_states.narrow(2, 0, hidden_states.size(2) - pad)
         return hidden_states
 
     def _add_extra_encoder(self, hidden_states, text_seq_length, attn):
+        # add padding for split and later all2all
+        # if pad is removed later than this
+        # the split size will be wrong
+        pad = get_pad("pad")
+        if pad > 0:
+            pad_shape = list(hidden_states.shape)
+            pad_shape[1] = pad
+            pad_tensor = torch.zeros(pad_shape, device=hidden_states.device, dtype=hidden_states.dtype)
+            hidden_states = torch.cat([hidden_states, pad_tensor], dim=1)
+
         # current layout is [text, seq]
         # we want to add the extra encoder info [text, 1/n seq, text, 1/n seq, ...]
         sp_size = attn.parallel_manager.sp_size
@@ -97,10 +114,10 @@ class CogVideoXAttnProcessor2_0:
                 attn.heads % attn.parallel_manager.sp_size == 0
             ), f"Number of heads {attn.heads} must be divisible by sequence parallel size {attn.parallel_manager.sp_size}"
             attn_heads = attn.heads // attn.parallel_manager.sp_size
+            # normally we operate pad for every all2all. but for more convient implementation
+            # we move pad operation to encoder add and remove in cogvideo
             query, key, value = map(
-                lambda x: all_to_all_comm(
-                    x, attn.parallel_manager.sp_group, scatter_dim=2, gather_dim=1
-                ),
+                lambda x: all_to_all_comm(x, attn.parallel_manager.sp_group, scatter_dim=2, gather_dim=1),
                 [query, key, value],
             )
         else:
@@ -145,12 +162,7 @@ class CogVideoXAttnProcessor2_0:
         if attn.parallel_manager.sp_size > 1:
             # add extra encoder for all_to_all
             hidden_states = self._add_extra_encoder(hidden_states, text_seq_length, attn)
-            hidden_states = all_to_all_comm(
-                hidden_states,
-                attn.parallel_manager.sp_group,
-                scatter_dim=1,
-                gather_dim=2
-            )
+            hidden_states = all_to_all_comm(hidden_states, attn.parallel_manager.sp_group, scatter_dim=1, gather_dim=2)
 
         # linear proj
         hidden_states = attn.to_out[0](hidden_states)


### PR DESCRIPTION
# 问题描述
使用 `examples/cogvideox/sample.py` 进行推理时，将num_gpus 设置为 4 时，会出下面的 bug：
```text
[rank0]:   File  "/workspace/VideoSys/examples/cogvideox/benchmark.py", line 68, in <module>
[rank0]:     run_base()
[rank0]:   File  "/workspace/VideoSys/examples/cogvideox/benchmark.py", line 22, in run_base
[rank0]:     video = engine.generate(
[rank0]:   File  "/workspace/VideoSys/videosys/core/engine.py", line 101, in generate
[rank0]:     return self._run_workers("generate", *args, **kwargs)[0]
[rank0]:   File  "/workspace/VideoSys/videosys/core/engine.py", line 92, in _run_workers
[rank0]:     driver_worker_output = driver_worker_method(*args, **kwargs)
[rank0]:   File "/data/miniconda3/envs/video_sys_py/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:   File  "/workspace/VideoSys/videosys/pipelines/cogvideox/pipeline_cogvideox.py", line 692, in generate
[rank0]:     noise_pred = self.transformer(
[rank0]:   File "/data/miniconda3/envs/video_sys_py/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/data/miniconda3/envs/video_sys_py/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:   File  "/workspace/VideoSys/videosys/models/transformers/cogvideox_transformer_3d.py", line 544, in forward
[rank0]:     hidden_states, encoder_hidden_states = block(
[rank0]:   File "/data/miniconda3/envs/video_sys_py/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/data/miniconda3/envs/video_sys_py/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:   File  "/workspace/VideoSys/videosys/models/transformers/cogvideox_transformer_3d.py", line 278, in forward
[rank0]:     attn_hidden_states, attn_encoder_hidden_states = self.attn1(
[rank0]:   File "/data/miniconda3/envs/video_sys_py/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/data/miniconda3/envs/video_sys_py/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:   File  "/workspace/diffusers/src/diffusers/models/attention_processor.py", line 490, in forward
[rank0]:     return self.processor(
[rank0]:   File  "/workspace/VideoSys/videosys/models/transformers/cogvideox_transformer_3d.py", line 131, in __call__
[rank0]:     query[:, :, text_seq_length : emb_len + text_seq_length] = apply_rotary_emb(
[rank0]:   File  "/workspace/VideoSys/videosys/models/modules/embeddings.py", line 404, in apply_rotary_emb
[rank0]:     out = (x.float() * cos + x_rotated.float() * sin).to(x.dtype)
[rank0]: RuntimeError: The size of tensor a (17548) must match the size of tensor b (17550) at non-singleton dimension 2
[09/26/24 20:42:45] ERROR    VideoSys - ERROR: Worker VideoSysWorkerProcess pid 87842 died, exit code: -15    
```

#  问题分析
1. 通过代码的分析，在 `CogVideoXAttnProcessor2_0` 的推理计算中，不应该使用  all_to_all_with_pad, 应该使用 "all_to_all_comm" 